### PR TITLE
Add option to show low quality loot (common and special loot)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -281,6 +281,7 @@ E:RegisterEvent("ADDON_LOADED", function(arg1)
 								type = "select",
 								name = L["RARITY_THRESHOLD"],
 								values = {
+									[0] = ITEM_QUALITY_COLORS[0].hex .. ITEM_QUALITY0_DESC .. "|r",
 									[1] = ITEM_QUALITY_COLORS[1].hex .. ITEM_QUALITY1_DESC .. "|r",
 									[2] = ITEM_QUALITY_COLORS[2].hex .. ITEM_QUALITY2_DESC .. "|r",
 									[3] = ITEM_QUALITY_COLORS[3].hex .. ITEM_QUALITY3_DESC .. "|r",

--- a/systems/loot_common.lua
+++ b/systems/loot_common.lua
@@ -321,6 +321,7 @@ E:RegisterOptions("loot_common", {
 			type = "select",
 			name = L["LOOT_THRESHOLD"],
 			values = {
+				[0] = ITEM_QUALITY_COLORS[0].hex .. ITEM_QUALITY0_DESC .. "|r",
 				[1] = ITEM_QUALITY_COLORS[1].hex .. ITEM_QUALITY1_DESC .. "|r",
 				[2] = ITEM_QUALITY_COLORS[2].hex .. ITEM_QUALITY2_DESC .. "|r",
 				[3] = ITEM_QUALITY_COLORS[3].hex .. ITEM_QUALITY3_DESC .. "|r",

--- a/systems/loot_special.lua
+++ b/systems/loot_special.lua
@@ -339,7 +339,6 @@ E:RegisterOptions("loot_special", {
 			type = "select",
 			name = L["LOOT_THRESHOLD"],
 			values = {
-				[0] = ITEM_QUALITY_COLORS[0].hex .. ITEM_QUALITY0_DESC .. "|r",
 				[1] = ITEM_QUALITY_COLORS[1].hex .. ITEM_QUALITY1_DESC .. "|r",
 				[2] = ITEM_QUALITY_COLORS[2].hex .. ITEM_QUALITY2_DESC .. "|r",
 				[3] = ITEM_QUALITY_COLORS[3].hex .. ITEM_QUALITY3_DESC .. "|r",

--- a/systems/loot_special.lua
+++ b/systems/loot_special.lua
@@ -339,6 +339,7 @@ E:RegisterOptions("loot_special", {
 			type = "select",
 			name = L["LOOT_THRESHOLD"],
 			values = {
+				[0] = ITEM_QUALITY_COLORS[0].hex .. ITEM_QUALITY0_DESC .. "|r",
 				[1] = ITEM_QUALITY_COLORS[1].hex .. ITEM_QUALITY1_DESC .. "|r",
 				[2] = ITEM_QUALITY_COLORS[2].hex .. ITEM_QUALITY2_DESC .. "|r",
 				[3] = ITEM_QUALITY_COLORS[3].hex .. ITEM_QUALITY3_DESC .. "|r",


### PR DESCRIPTION
Hi, thanks for developing this great addon! :)
I added the option to also display grey quality loot, tested it and it seems to work fine.
No LUA-Error are popping up.
I did not touch the defaults so the "out of the box" experience is unchanged.