### PR TITLE
Fix addon.C being reassigned to a new table

### DIFF
--- a/ls_Toasts/core/defaults.lua
+++ b/ls_Toasts/core/defaults.lua
@@ -1,9 +1,7 @@
 local _, addon = ...
+local D = addon.D
 
 -- Mine
-local C, D = {}, {}
-addon.C, addon.D = C, D
-
 local function rgb(...)
 	return addon:CreateColor(...)
 end


### PR DESCRIPTION
In `defaults.lua`, `addon.C` was reassigned to a new empty table, breaking the original reference created in `core.lua`.
As a result, `_G.ls_Toasts[2]` still pointed to the old table and remained empty.